### PR TITLE
feat: allow requesting by short name too

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Terraform module is designed to provide information on Azure locations.
 
-It provides for an Azure location name or display name : name, display name, regional display name, short name and paired region name.
+It provides for an Azure location name, short name or display name : name, display name, regional display name, short name and paired region name.
 
 Please refer to the [locations.json](locations.json) file for available locations. The list was build based on this command line :   
 ```
@@ -39,7 +39,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| location | The location/region name or displayName to get information. | `string` | n/a | yes |
+| location | The location/region name, shortName or displayName to get information. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -55,7 +55,7 @@ No resources.
 
 ## Related documentation
 
-[Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/regions/)  
-[Azure Geo-code mapping](https://learn.microsoft.com/en-us/azure/backup/scripts/geo-code-list)  
-[Terrafomr modules](https://developer.hashicorp.com/terraform/registry/modules/publish)  
-[Terraform Best Practices](https://www.terraform-best-practices.com/)  
+[Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/regions/)
+[Azure Geo-code mapping](https://learn.microsoft.com/en-us/azure/backup/scripts/geo-code-list)
+[Terrafomr modules](https://developer.hashicorp.com/terraform/registry/modules/publish)
+[Terraform Best Practices](https://www.terraform-best-practices.com/)

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ No resources.
 
 [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/regions/)
 [Azure Geo-code mapping](https://learn.microsoft.com/en-us/azure/backup/scripts/geo-code-list)
-[Terrafomr modules](https://developer.hashicorp.com/terraform/registry/modules/publish)
+[Terraform modules](https://developer.hashicorp.com/terraform/registry/modules/publish)
 [Terraform Best Practices](https://www.terraform-best-practices.com/)

--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,22 @@ locals {
     }
   }
 
+  locations_short_name = {
+    for location in local.locations_data.locations : location.shortName => {
+      name                  = location.name
+      display_name          = location.displayName
+      short_name            = location.shortName
+      regional_display_name = location.regionalDisplayName
+      paired_region_name    = location.pairedRegionName
+    } if location.shortName != null
+  }
+
   lookup_name         = lookup(local.locations_name, var.location, null)
   lookup_display_name = lookup(local.locations_display_name, var.location, null)
+  lookup_short_name   = lookup(local.locations_short_name, var.location, null)
   location = try(coalesce(
     local.lookup_name,
-    local.lookup_display_name
+    local.lookup_display_name,
+    local.lookup_short_name
   ), "none")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
 variable "location" {
-  description = "(Required) The location/region name or displayName to get information."
+  description = "(Required) The location/region name, shortName or displayName to get information."
   type        = string
 }


### PR DESCRIPTION
# Context

This PR allows requesting the azurerm/locations/azure module with a short region name in addition to its name or display name.

# Notes

This PR cannot be merged without breaking the module before #10 is merged. 
Indeed, there are 2 duplicated short names:
- `ae` used by both `austriaeast` and `australiaeast`
- `jic` used by both `jioindiawest` and `jioindiacentral`

These cause the error "Duplicate object key" when loading the module.